### PR TITLE
Add action for automation build binaries and release + bump golang

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ${{ env.BIN_PATH }}
-          pattern: SNI-Finder-*
+          pattern: ${{ env.PKG_NAME }}-*
           merge-multiple: true
 
       - name: Display structure of downloaded files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  BIN_PATH: /tmp/bin
+  PKG_NAME: "countdowndsm"
+
+jobs:
+  build:
+    name: Build binaries
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        arch: [amd64, arm64]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.14'
+          cache: false
+
+      - name: Run go mod tidy
+        run: go mod tidy
+
+      - name: Set environment variables
+        run: |
+          if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
+            echo "GOOS=linux" >> $GITHUB_ENV
+          elif [ "${{ matrix.os }}" == "macos-latest" ]; then
+            echo "GOOS=darwin" >> $GITHUB_ENV
+          else
+            echo "GOOS=windows" >> $GITHUB_ENV
+            echo "EXT=.exe" >> $GITHUB_ENV
+          fi
+
+      - name: Build binary
+        env:
+          GOARCH: ${{ matrix.arch }}
+          GOOS: ${{ env.GOOS }}
+          EXT: ${{ env.EXT }}
+        run: |
+          go build -o ${{ env.PKG_NAME }}-${{ env.GOOS }}-${{ matrix.arch }}${{ env.EXT }} .
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PKG_NAME }}-${{ env.GOOS }}-${{ matrix.arch }}${{ env.EXT }}
+          path: ${{ env.PKG_NAME }}-${{ env.GOOS }}-${{ matrix.arch }}${{ env.EXT }}
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create bin directory
+        run: |
+          mkdir -p ${{ env.BIN_PATH }}
+
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ env.BIN_PATH }}
+          pattern: SNI-Finder-*
+          merge-multiple: true
+
+      - name: Display structure of downloaded files
+        run: ls -R ${{ env.BIN_PATH }}
+
+      - name: Release with assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ env.BIN_PATH }}/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.14'
+          go-version: '1.21'
           cache: false
 
       - name: Run go mod tidy

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,13 @@
 module github.com/picknick/countdowndsm
 
-go 1.14
+go 1.21
+
+require (
+	github.com/nsf/termbox-go v1.1.1
+	gopkg.in/yaml.v2 v2.4.0
+)
 
 require (
 	github.com/mattn/go-runewidth v0.0.13 // indirect
-	github.com/nsf/termbox-go v1.1.1
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/nsf/termbox-go v1.1.1 h1:nksUPLCb73Q++DwbYUBEglYBRPZyoXJdrj5L+TkjyZY=
 github.com/nsf/termbox-go v1.1.1/go.mod h1:T0cTdVuOwf7pHQNtfhnEbzHbcNyCEcVU4YPpouCbVxo=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
* Added automatic build and release from tag.
* Bumped Golang to 1.21 for windows arm build


Build for all possible OS variations and architectures.

```
countdowndsm-darwin-amd64
countdowndsm-darwin-arm64
countdowndsm-linux-amd64
countdowndsm-linux-arm64
countdowndsm-windows-amd64.exe
countdowndsm-windows-arm64.exe
```

The release process is trivial:
- create a new tag in the console
```
❯ git tag v1.2.3
```

- push tags
```
❯ git push origin --tags
Warning: Permanently added 'github.com' (ED25519) to the list of known hosts.
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:v-kamerdinerov/countdowndsm.git
 * [new tag]         v1.2.3 -> v1.2.3

```

- enjoy automatic binary build and release

<img width="783" alt="image" src="https://github.com/user-attachments/assets/4fad8e28-4014-4f26-a164-e44dfaf5e1bc">
<img width="717" alt="image" src="https://github.com/user-attachments/assets/3ccdbdc8-f0b7-419f-80e0-ab8e45185f7c">
<img width="1245" alt="image" src="https://github.com/user-attachments/assets/20ce2562-1457-43eb-aa5b-be25695074e4">

